### PR TITLE
Backflow method (Fischer) & Fix

### DIFF
--- a/oasis/problems/NSfracStep/__init__.py
+++ b/oasis/problems/NSfracStep/__init__.py
@@ -60,14 +60,20 @@ NS_parameters.update(
         rho=1085        # kg/m^3
         ),
 
-    # Back flow stabilization (Velocity gradient)
+    # Backflow stabilization (Velocity gradient)
     backflow_facets_grad=[],
     backflow_gamma=0.001 / 3,  # dx**2 / 3
 
-    # Back flow stabilization (Convective boundary)
+    # Backflow stabilization (Convective boundary)
     backflow_facets_conv=[],
+    backflow_U_conv=122,  # Convective velocity # TODO: Make problem specific
 
-    # Back flow stabilization, turned on if back_flow_facets is != [] and boundaries is not None
+    # Backflow stabilization (Divergence function)
+    backflow_div_method=None,  # Divergence applied to domain: either 'full' or 'short'
+    mesh_distance=[],  # Array of distance between vertex points and specified boundary
+    D=6.35,  # Length to move away from boundary in Fischer method
+
+    # Backflow stabilization, turned on if back_flow_facets is != [] and boundaries is not None
     backflow_facets=[],  # List of facet value(s) in MeshFunction (boundaries) to apply back flow stabilization
     backflow_beta=0.2,  # Standard value from Moghadam et al. Comput Mech (2011) 48:277–291
 

--- a/oasis/problems/NSfracStep/find_boundary_distance.py
+++ b/oasis/problems/NSfracStep/find_boundary_distance.py
@@ -1,0 +1,35 @@
+from dolfin import *
+
+
+def find_distance(mesh, ignore_domain):
+    """
+    mesh: Mesh to calculate distance on
+    Ignore_domain: Part of boundary to be ignored, specified with e.g. AutoSubDomain()
+    """
+    if MPI.comm_world.Get_size() == 1:
+        bmesh = BoundaryMesh(mesh, 'exterior')
+        cell_f = MeshFunction('size_t', bmesh, 0)
+        ignore_domain.mark(cell_f, 1)
+
+        bmesh_sub = SubMesh(bmesh, cell_f, 0)
+        File('submesh1.xml') << bmesh_sub
+
+    # FIXME: Does not work in parallel
+    if MPI.comm_world.Get_size() >= 1:
+        if MPI.comm_world.Get_size() > 1:
+            bmesh_sub = Mesh("submesh1.xml")
+
+        tree = bmesh_sub.bounding_box_tree()
+
+        V = FunctionSpace(mesh, 'CG', 1)
+        v_2_d = V.dofmap().entity_dofs(mesh, 0)
+
+        bdry_distance = Function(V)
+        values = bdry_distance.vector().get_local(v_2_d)
+        for index, vertex in enumerate(vertices(mesh)):
+            w, d = tree.compute_closest_entity(vertex.point())
+            values[v_2_d[index]] = d
+        bdry_distance.vector().set_local(values)
+        bdry_distance.vector().apply('insert')
+
+    return bdry_distance.vector()


### PR DESCRIPTION
- Added Fischer method
- Fix to velocity penalization method

To use Fischer add following to NS_parameters:
```
NS_parameters.update(
        backflow_div_method="full", # or 'short' 
        # For 'short' method one needs to specify max length of divergence area, e.g. diameter (D)
        D=6.35
)
```

Also need to define boundary of interest (in 'pre_boundary_condition'):
```
from .find_boundary_distance import find_distance

def pre_boundary_condition():
    ...
    # Example with 2D stenosis in the domain [-3D, 8D] x [-D/2 D/2], D=diameter
    ignore_domain = AutoSubDomain(lambda x, b: near(x[0], -3*D) or near(x[1], -D / 2) or near(x[1], D / 2))
    mesh_distance = find_distance(mesh, ignore_domain)

    return dict(boundary=boundary, mesh_distance=mesh_distance)
```